### PR TITLE
Use SecretStorage for auth token instead of public file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ You can copy the token from the Bitburner application 'API Server' context menu:
 
 #### Adding the token to the extension:
 
-The token will ultimately end up in the workspace configuration (See your workspaces`./.vscode/settings.json`), so you can either:
-
-- Add the token manually to the workspace `settings.json` to the key of `bitburner.authToken`.
 - Use the command palette (CTRL/CMD + SHIFT + P) and select `Bitburner: Add Auth Token`.
   - Paste the Auth Token copied via the games context menu in to the input box.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "url": "https://github.com/hexnaught/vscode-bitburner-connector/issues"
   },
   "contributors": [
-    "Hexnaught <danj.parkes@gmail.com>"
+    "Hexnaught <danj.parkes@gmail.com>",
+    "Malanius <malaniusprivierre@gmail.com>"
   ],
   "categories": [
     "Other"


### PR DESCRIPTION
Since the settings.json is public and likely to be committed, it's better not to store private information in it.